### PR TITLE
fix: extract shared server runtime and fix production caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "exports": {
     ".": "./src/elizabeth.ts",
     "./client": "./src/client.ts",
-    "./route": "./src/route.ts"
+    "./route": "./src/route.ts",
+    "./server": "./src/runtime/server.ts"
   },
   "scripts": {
     "check": "tsc --noEmit",

--- a/src/build/app.ts
+++ b/src/build/app.ts
@@ -223,6 +223,18 @@ async function writeServerEntry(
 import { stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  apiRouteBuildFailureResponse,
+  methodNotAllowedResponse,
+  renderApiRoute,
+  renderPageRoute,
+  responseFromResult,
+  isRedirectResult,
+  isNotFoundResult,
+  runMiddleware,
+  createRequestContext,
+  resolveMiddleware
+} from "elizabeth/server";
 
 const distDir = dirname(fileURLToPath(import.meta.url));
 const routes = ${JSON.stringify(serverRoutes, null, 2)};
@@ -245,7 +257,6 @@ const compiledLoadingRoutes = loadingRoutes.map(compileServerRoute);
 const exactRoutes = exactRouteMap(compiledRoutes);
 const exactApiRoutes = exactRouteMap(compiledApiRoutes);
 const moduleCache = new Map();
-const staticHtmlCache = new Map();
 const cssLinkMarkup = renderCssLinks(cssHrefs);
 const buildBootstrapScript = renderBuildBootstrap(hasIslands);
 const requestLoggingEnabled = Bun.env.ELIZABETH_REQUEST_LOGS !== "0";
@@ -253,7 +264,6 @@ const userConfig = await import(configUrl).then((module) => module.default ?? {}
 const configMiddleware = collectConfigMiddleware(userConfig);
 
 await preloadServerModules();
-await preloadStaticHtml();
 
 const port = Number(Bun.env.PORT ?? 3712);
 
@@ -328,7 +338,7 @@ const apiMatch = matchRoute(compiledApiRoutes, pathname, exactApiRoutes);
 
     if (apiMatch && apiMatch.route.methods.includes(method)) {
       const context = createRequestContext(request, pathname, apiMatch.params);
-      return runMiddleware(resolveMiddleware(apiMatch.route.middleware), context, () => renderApiRoute(apiMatch, request, method, context));
+      return runMiddleware(resolveMiddlewareWrapper(apiMatch.route.middleware), context, () => renderApiRoute(apiMatch, method, request, (route) => getServerModule(route.module), context, () => renderNotFound(pathname, request)));
     }
 
     if (apiMatch && !["GET", "HEAD"].includes(method)) {
@@ -344,23 +354,15 @@ const apiMatch = matchRoute(compiledApiRoutes, pathname, exactApiRoutes);
 }
 
 function renderMatchedRoute(match, status, pathname, request) {
-  if (status === 200 && match.route.static && !hasMiddleware(match.route)) {
-    const cached = staticHtmlCache.get(match.route.path);
-
-    if (cached) {
-      return htmlResponse(cached, 200);
-    }
-  }
-
   const context = createRequestContext(request, pathname, match.params, match.error);
-  return runMiddleware(resolveMiddleware(match.route.middleware), context, () => renderMatchedRouteWithoutMiddleware(match, status, pathname, context));
+  return runMiddleware(resolveMiddlewareWrapper(match.route.middleware), context, () => renderMatchedRouteWithoutMiddleware(match, status, pathname, context));
 }
 
 function renderMatchedRouteWithoutMiddleware(match, status, pathname, context) {
   let result;
 
   try {
-    result = renderRoute(match, context);
+    result = renderPageRoute(match, (module) => getServerModule(module), context);
   } catch (error) {
     return renderError(pathname, error, context.request);
   }
@@ -389,74 +391,7 @@ function renderRouteResult(result, status, pathname, context) {
   return htmlResponse(withBuildBootstrap(withCssLinks(result, cssHrefs), hasIslands), status);
 }
 
-function renderApiRoute(match, request, method, context = createRequestContext(request, new URL(request.url).pathname, match.params)) {
-  if (match.route.error) {
-    return apiRouteBuildFailureResponse(match.route);
-  }
 
-  const module = getServerModule(match.route.module);
-  let handler = match.route.handlers?.[method];
-
-  if (!handler) {
-    handler = module[method];
-    match.route.handlers ??= {};
-    match.route.handlers[method] = handler;
-  }
-
-  if (typeof handler !== "function") {
-    return methodNotAllowedResponse(match.route.methods);
-  }
-
-  const result = handler(context);
-
-  if (result instanceof Promise) {
-    return result.then((resolved) => apiRouteResultResponse(resolved, new URL(request.url).pathname));
-  }
-
-  return apiRouteResultResponse(result, new URL(request.url).pathname);
-}
-
-function apiRouteResultResponse(result, pathname) {
-  if (result instanceof Response) {
-    return result;
-  }
-
-  if (isRedirectResult(result)) {
-    return new Response(null, {
-      status: result.status,
-      headers: { location: result.location },
-    });
-  }
-
-  if (isNotFoundResult(result)) {
-    return renderNotFound(pathname, context.request);
-  }
-
-  if (typeof result === "string") {
-    return new Response(result, {
-      headers: { "content-type": "text/html; charset=utf-8" },
-    });
-  }
-
-  return Response.json(result);
-}
-
-function apiRouteBuildFailureResponse(route) {
-  return new Response("API route failed to build: " + route.path + "\\n" + (route.error ?? "Unknown error"), {
-    status: 500,
-    headers: { "content-type": "text/plain; charset=utf-8" },
-  });
-}
-
-function methodNotAllowedResponse(methods) {
-  return new Response("Method Not Allowed", {
-    status: 405,
-    headers: {
-      allow: methods.join(", "),
-      "content-type": "text/plain; charset=utf-8",
-    },
-  });
-}
 
 function renderNotFound(pathname, request) {
   const match = matchSpecialRoute(compiledNotFoundRoutes, pathname);
@@ -470,7 +405,7 @@ function renderNotFound(pathname, request) {
 
   const context = request ? createRequestContext(request, pathname, match.params) : null;
   return runMaybeMiddleware(match.route, context, () => {
-    const result = renderRoute(match, context);
+    const result = renderPageRoute(match, (module) => getServerModule(module), context);
 
     if (result instanceof Promise) {
       return result.then((resolved) => renderNotFoundResult(resolved));
@@ -492,7 +427,7 @@ function renderError(pathname, error, request) {
 
   const context = request ? createRequestContext(request, pathname, match.params, error) : null;
   return runMaybeMiddleware(match.route, context, () => {
-    const result = renderRoute({ ...match, error }, context);
+    const result = renderPageRoute({ ...match, error }, (module) => getServerModule(module), context);
 
     if (result instanceof Promise) {
       return result.then((resolved) => renderErrorResult(resolved, pathname, request));
@@ -526,7 +461,7 @@ function renderLoading(pathname, request) {
 
   const context = request ? createRequestContext(request, pathname, match.params) : null;
   return runMaybeMiddleware(match.route, context, () => {
-    const result = renderRoute(match, context);
+    const result = renderPageRoute(match, (module) => getServerModule(module), context);
 
     if (result instanceof Promise) {
       return result.then(renderLoadingResult);
@@ -567,72 +502,20 @@ function runMaybeMiddleware(route, context, handler) {
     return handler();
   }
 
-  return runMiddleware(resolveMiddleware(route.middleware), context, handler);
+  return runMiddleware(resolveMiddlewareWrapper(route.middleware), context, handler);
 }
 
-async function runMiddleware(middleware, context, handler) {
-  let index = -1;
 
-  async function dispatch(nextIndex) {
-    if (nextIndex <= index) {
-      throw new Error("Middleware called next() more than once.");
-    }
 
-    index = nextIndex;
-    const current = middleware[nextIndex];
-
-    if (!current) {
-      return await handler();
-    }
-
-    return await current(context, () => dispatch(nextIndex + 1));
-  }
-
-  return await dispatch(0);
-}
-
-function resolveMiddleware(references = []) {
-  const middleware = [];
-
-  for (let index = 0; index < globalMiddlewareCount; index++) {
-    const entry = configMiddleware[index];
-    if (entry) middleware.push(entry);
-  }
-
-  for (const reference of references) {
-    if (reference.kind === "config") {
-      const entry = configMiddleware[reference.index];
-      if (entry) middleware.push(entry);
-      continue;
-    }
-
-    const module = getServerModule(reference.module);
-    const entry = module?.default ?? module?.middleware;
-
-    if (typeof entry !== "function") {
-      throw new Error("Middleware module must export a default function or named middleware: " + reference.sourcePath);
-    }
-
-    middleware.push(entry);
-  }
-
-  return middleware;
+function resolveMiddlewareWrapper(references) {
+  return resolveMiddleware(references, globalMiddlewareCount, (index) => configMiddleware[index], getServerModule);
 }
 
 function hasMiddleware(route) {
   return globalMiddlewareCount > 0 || route.middleware?.length > 0;
 }
 
-function createRequestContext(request, pathname, params, error) {
-  return {
-    request,
-    pathname,
-    params,
-    locals: {},
-    error,
-    get url() { return new URL(request.url); },
-  };
-}
+
 
 function collectConfigMiddleware(config) {
   return [
@@ -660,43 +543,6 @@ function middlewareArray(value) {
   return Array.isArray(value) ? value.filter((entry) => typeof entry === "function") : [];
 }
 
-function renderRoute(match, context) {
-  const ctx = context ?? { params: match.params, error: match.error, locals: {} };
-  const page = getServerModule(match.route.module);
-  const html = page.default({}, ctx);
-
-  if (html instanceof Promise) {
-    return html.then((resolved) => renderRouteLayouts(match, ctx, resolved));
-  }
-
-  return renderRouteLayouts(match, ctx, html);
-}
-
-function renderRouteLayouts(match, ctx, html) {
-  if (isRedirectResult(html) || isNotFoundResult(html)) {
-    return html;
-  }
-
-  let current = html;
-
-  for (let index = match.route.layouts.length - 1; index >= 0; index--) {
-    const layout = match.route.layouts[index];
-    const module = getServerModule(layout.module);
-    current = module.default({
-      children: routeBoundary(boundaryKey(layout.hash, match.params, index), current),
-    }, ctx);
-
-    if (current instanceof Promise) {
-      return current.then((resolved) => renderRemainingRouteLayouts(match, ctx, resolved, index - 1));
-    }
-
-    if (isRedirectResult(current) || isNotFoundResult(current)) {
-      return current;
-    }
-  }
-
-  return current.includes("data-elizabeth-style=") ? dedupeElizabethStyles(current) : current;
-}
 
 function renderRemainingRouteLayouts(match, ctx, html, startIndex) {
   if (isRedirectResult(html) || isNotFoundResult(html)) {
@@ -746,22 +592,6 @@ async function preloadServerModules() {
   }));
 }
 
-async function preloadStaticHtml() {
-  await Promise.all(compiledRoutes.filter((route) => route.static && !hasMiddleware(route)).map(async (route) => {
-    let result;
-
-    try {
-      result = await renderRoute({ route, params: {} });
-    } catch {
-      return;
-    }
-
-    if (!isRedirectResult(result) && !isNotFoundResult(result)) {
-      staticHtmlCache.set(route.path, withBuildBootstrap(withCssLinks(result, cssHrefs), hasIslands));
-    }
-  }));
-}
-
 function getServerModule(specifier) {
   return moduleCache.get(specifier);
 }
@@ -787,28 +617,9 @@ function exactRouteMap(routes) {
   return map;
 }
 
-function routeBoundary(key, html) {
-  return \`<elizabeth-route-boundary data-elizabeth-boundary="\${escapeAttribute(key)}" style="display: contents">\${html}</elizabeth-route-boundary>\`;
-}
 
-function boundaryKey(layoutHash, params, layoutIndex) {
-  if (layoutIndex === 0) return \`layout:\${layoutHash}:\`;
-  let key = "";
-  for (const name in params) key += name + "=" + params[name] + "&";
-  return \`layout:\${layoutHash}:\${key}\`;
-}
 
-function escapeAttribute(value) {
-  return Bun.escapeHTML(String(value));
-}
 
-function hashString(value) {
-  let hash = 5381;
-  for (let index = 0; index < value.length; index++) {
-    hash = ((hash << 5) + hash) ^ value.charCodeAt(index);
-  }
-  return (hash >>> 0).toString(36);
-}
 
 function matchRoute(routes, pathname, exact) {
   const exactRoute = exact.get(pathname);
@@ -1041,26 +852,9 @@ function withBuildBootstrap(html, enabled) {
   return \`\${html}\${script}\`;
 }
 
-function dedupeElizabethStyles(html) {
-  const seen = new Set();
 
-  return html.replace(/<style\\b([^>]*\\sdata-elizabeth-style=(["'])(.*?)\\2[^>]*)>[\\s\\S]*?<\\/style>/g, (style, _attrs, _quote, id) => {
-    if (seen.has(id)) {
-      return "";
-    }
 
-    seen.add(id);
-    return style;
-  });
-}
 
-function isRedirectResult(value) {
-  return Boolean(value && typeof value === "object" && value[redirectMarker] === true);
-}
-
-function isNotFoundResult(value) {
-  return Boolean(value && typeof value === "object" && value[notFoundMarker] === true);
-}
 
 function logRequest(entry) {
   const method = color(entry.method.padEnd(6), "\\x1b[36m");

--- a/src/dev/app.ts
+++ b/src/dev/app.ts
@@ -23,6 +23,7 @@ import {
 import type { PageRouteManifest } from "../router/pages.ts";
 import { buildPageRoutes, matchPageRoute, matchSpecialPageRoute } from "../router/pages.ts";
 import { type RenderModuleCache, renderPageRoute } from "../router/render.ts";
+import { renderApiRoute, methodNotAllowedResponse, createRequestContext, resolveMiddleware } from "../runtime/server.ts";
 import { renderDevError } from "./error.ts";
 import { createHmrRuntime } from "./hmr.ts";
 
@@ -212,11 +213,19 @@ export function createElizabethDevHandler(options: ElizabethDevOptions): Elizabe
     }
     if (apiMatch && apiMatch.route.methods.includes(method)) {
       const context = createRequestContext(request, pathname, apiMatch.params);
-      const middleware = await resolveMiddleware(config, apiMatch.route.middleware);
+      const middleware = await resolveMiddlewareWrapper(config, apiMatch.route.middleware);
 
       return devResult(
         await runMiddleware(middleware, context, () =>
-          renderApiRoute(apiMatch, method, request, apiModuleCache, context),
+          renderApiRoute(apiMatch, method, request, async (route) => {
+            const modulePath = route.outputPath!;
+            let pending = apiModuleCache?.get(modulePath);
+            if (!pending) {
+              pending = import(`${pathToFileURL(modulePath).href}?t=${Date.now()}`) as Promise<Record<string, unknown>>;
+              apiModuleCache?.set(modulePath, pending);
+            }
+            return pending;
+          }, context),
         ),
         "api",
       );
@@ -233,7 +242,7 @@ export function createElizabethDevHandler(options: ElizabethDevOptions): Elizabe
     }
 
     const context = createRequestContext(request, pathname, match.params);
-    const middleware = await resolveMiddleware(config, match.route.middleware);
+    const middleware = await resolveMiddlewareWrapper(config, match.route.middleware);
 
     return devResult(await runMiddleware(middleware, context, async () => {
       let result: Awaited<ReturnType<typeof renderPageRoute>>;
@@ -300,7 +309,7 @@ export function createElizabethDevHandler(options: ElizabethDevOptions): Elizabe
     };
 
     if (context && config) {
-      return await runMiddleware(await resolveMiddleware(config, match.route.middleware), context, render);
+      return await runMiddleware(await resolveMiddlewareWrapper(config, match.route.middleware), context, render);
     }
 
     return await render();
@@ -348,7 +357,7 @@ export function createElizabethDevHandler(options: ElizabethDevOptions): Elizabe
     };
 
     if (context && config) {
-      return await runMiddleware(await resolveMiddleware(config, match.route.middleware), context, render);
+      return await runMiddleware(await resolveMiddlewareWrapper(config, match.route.middleware), context, render);
     }
 
     return await render();
@@ -387,60 +396,17 @@ export function createElizabethDevHandler(options: ElizabethDevOptions): Elizabe
     };
 
     if (context && config) {
-      return await runMiddleware(await resolveMiddleware(config, match.route.middleware), context, render);
+      return await runMiddleware(await resolveMiddlewareWrapper(config, match.route.middleware), context, render);
     }
 
     return await render();
   }
 
-  function createRequestContext(
-    request: Request,
-    pathname: string,
-    params: Record<string, string>,
-    error?: unknown,
-  ): ElizabethRequestContext {
-    return {
-      request,
-      pathname,
-      params,
-      locals: {},
-      error,
-      get url() {
-        return new URL(request.url);
-      },
-    };
-  }
-
-  async function resolveMiddleware(
+  async function resolveMiddlewareWrapper(
     config: ElizabethConfig,
     references: MiddlewareReference[],
   ): Promise<ElizabethMiddleware[]> {
-    const globalReferences: MiddlewareReference[] = Array.from(
-      { length: config.globalMiddlewareCount },
-      (_value, index) => ({ kind: "config", index }),
-    );
-    const middleware: ElizabethMiddleware[] = [];
-
-    for (const reference of [...globalReferences, ...references]) {
-      if (reference.kind === "config") {
-        const entry = config.middleware[reference.index];
-        if (entry) {
-          middleware.push(entry);
-        }
-        continue;
-      }
-
-      const module = await importMiddlewareModule(reference.outputPath);
-      const entry = module.default ?? module.middleware;
-
-      if (typeof entry !== "function") {
-        throw new Error(`Middleware module must export a default function or named middleware: ${reference.sourcePath}`);
-      }
-
-      middleware.push(entry as ElizabethMiddleware);
-    }
-
-    return middleware;
+    return resolveMiddleware(references, config.globalMiddlewareCount, (index) => config.middleware[index], importMiddlewareModule);
   }
 
   async function importMiddlewareModule(path: string): Promise<Record<string, unknown>> {
@@ -720,80 +686,7 @@ export function createElizabethDevHandler(options: ElizabethDevOptions): Elizabe
   }
 }
 
-async function renderApiRoute(
-  match: { route: ApiRoute; params: Record<string, string> },
-  method: string,
-  request: Request,
-  moduleCache?: Map<string, Promise<Record<string, unknown>>>,
-  context?: ElizabethRequestContext,
-): Promise<Response> {
-  if (match.route.error) {
-    return apiRouteBuildFailureResponse(match.route);
-  }
 
-  const modulePath = match.route.outputPath!;
-  let pending = moduleCache?.get(modulePath);
-
-  if (!pending) {
-    pending = import(`${pathToFileURL(modulePath).href}?t=${Date.now()}`) as Promise<Record<string, unknown>>;
-    moduleCache?.set(modulePath, pending);
-  }
-
-  const module = await pending;
-  const handler = module[method];
-
-  if (typeof handler !== "function") {
-    return methodNotAllowedResponse(match.route.methods);
-  }
-
-  const result = await handler(
-    context ?? {
-      request,
-      pathname: new URL(request.url).pathname,
-      params: match.params,
-      locals: {},
-      get url() {
-        return new URL(request.url);
-      },
-    },
-  );
-
-  if (result instanceof Response) {
-    return result;
-  }
-
-  if (isRedirectResult(result)) {
-    return redirectResponse(result.location, result.status);
-  }
-
-  if (isNotFoundResult(result)) {
-    return new Response("Not found", {
-      status: 404,
-      headers: {
-        "content-type": "text/plain; charset=utf-8",
-      },
-    });
-  }
-
-  if (typeof result === "string") {
-    return new Response(result, {
-      headers: {
-        "content-type": "text/html; charset=utf-8",
-      },
-    });
-  }
-
-  return Response.json(result);
-}
-
-function apiRouteBuildFailureResponse(route: ApiRoute): Response {
-  return new Response(`API route failed to build: ${route.path}\n${route.error ?? "Unknown error"}`, {
-    status: 500,
-    headers: {
-      "content-type": "text/plain; charset=utf-8",
-    },
-  });
-}
 
 function logDevRequest(entry: {
   method: string;
@@ -865,15 +758,7 @@ function color(value: string, code: string): string {
   return `${code}${value}\x1b[0m`;
 }
 
-function methodNotAllowedResponse(methods: string[]): Response {
-  return new Response("Method Not Allowed", {
-    status: 405,
-    headers: {
-      allow: methods.join(", "),
-      "content-type": "text/plain; charset=utf-8",
-    },
-  });
-}
+
 
 function assertNoRouteConflicts(
   pageRoutes: Array<{ path: string; methods: string[]; sourcePath: string }>,

--- a/src/dev/app.ts
+++ b/src/dev/app.ts
@@ -23,7 +23,7 @@ import {
 import type { PageRouteManifest } from "../router/pages.ts";
 import { buildPageRoutes, matchPageRoute, matchSpecialPageRoute } from "../router/pages.ts";
 import { type RenderModuleCache, renderPageRoute } from "../router/render.ts";
-import { renderApiRoute, methodNotAllowedResponse, createRequestContext, resolveMiddleware } from "../runtime/server.ts";
+import { renderApiRoute, methodNotAllowedResponse, createRequestContext, resolveMiddleware, apiRouteBuildFailureResponse } from "../runtime/server.ts";
 import { renderDevError } from "./error.ts";
 import { createHmrRuntime } from "./hmr.ts";
 

--- a/src/router/middleware.ts
+++ b/src/router/middleware.ts
@@ -38,7 +38,13 @@ export async function runMiddleware(
     }
 
     index = nextIndex;
-    const current = middleware[nextIndex];
+    let current;
+    
+    if (middleware instanceof Promise) {
+      middleware = await middleware;
+    }
+    
+    current = middleware[nextIndex];
 
     if (!current) {
       return await handler();

--- a/src/router/render.ts
+++ b/src/router/render.ts
@@ -1,7 +1,8 @@
 import { pathToFileURL } from "node:url";
-import { isNotFoundResult, isRedirectResult, type NotFoundResult, type RedirectResult } from "../route.ts";
+import { type NotFoundResult, type RedirectResult } from "../route.ts";
 import type { ElizabethRequestContext } from "./middleware.ts";
 import type { PageRouteMatch } from "./pages.ts";
+import { renderPageRoute as sharedRenderPageRoute } from "../runtime/server.ts";
 
 export type RenderRouteResult = string | RedirectResult | NotFoundResult;
 export interface RenderPageContext {
@@ -27,32 +28,16 @@ export async function renderPageRoute(
   match: PageRouteMatch,
   options: RenderPageRouteOptions = {},
 ): Promise<RenderRouteResult> {
-  const ctx = options.context
-    ? { ...options.context, params: match.params, error: match.error }
-    : { params: match.params, error: match.error, locals: {} };
-  const page = await importRenderModule(match.route.outputPath, options.moduleCache);
-  let html = await page.default({}, ctx);
+  const result = sharedRenderPageRoute(
+    match,
+    (path: string) => importRenderModule(path, options.moduleCache),
+    options.context
+  );
 
-  if (isRedirectResult(html) || isNotFoundResult(html)) {
-    return html;
+  if (result instanceof Promise) {
+    return await result;
   }
-
-  for (let index = match.route.layouts.length - 1; index >= 0; index--) {
-    const layout = match.route.layouts[index];
-    const module = await importRenderModule(layout.outputPath, options.moduleCache);
-    html = await module.default(
-      {
-        children: routeBoundary(boundaryKey(layout.sourcePath, match.params, index), html),
-      },
-      ctx,
-    );
-
-    if (isRedirectResult(html) || isNotFoundResult(html)) {
-      return html;
-    }
-  }
-
-  return dedupeElizabethStyles(html);
+  return result;
 }
 
 async function importRenderModule(path: string, cache?: RenderModuleCache): Promise<RenderModule> {
@@ -70,45 +55,4 @@ async function importRenderModule(path: string, cache?: RenderModuleCache): Prom
   }
 
   return await pending;
-}
-
-function dedupeElizabethStyles(html: string): string {
-  const seen = new Set<string>();
-
-  return html.replace(
-    /<style\b([^>]*\sdata-elizabeth-style=(["'])(.*?)\2[^>]*)>[\s\S]*?<\/style>/g,
-    (style, _attrs: string, _quote: string, id: string) => {
-      if (seen.has(id)) {
-        return "";
-      }
-
-      seen.add(id);
-      return style;
-    },
-  );
-}
-
-function routeBoundary(key: string, html: string): string {
-  return `<elizabeth-route-boundary data-elizabeth-boundary="${escapeAttribute(key)}" style="display: contents">${html}</elizabeth-route-boundary>`;
-}
-
-function boundaryKey(sourcePath: string, params: Record<string, string>, layoutIndex: number): string {
-  if (layoutIndex === 0) return `layout:${hashString(sourcePath)}:`;
-  let key = "";
-  for (const name in params) key += name + "=" + params[name] + "&";
-  return `layout:${hashString(sourcePath)}:${key}`;
-}
-
-function escapeAttribute(value: string): string {
-  return Bun.escapeHTML(value);
-}
-
-function hashString(value: string): string {
-  let hash = 5381;
-
-  for (let index = 0; index < value.length; index++) {
-    hash = ((hash << 5) + hash) ^ value.charCodeAt(index);
-  }
-
-  return (hash >>> 0).toString(36);
 }

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -1,0 +1,264 @@
+import { isNotFoundResult, isRedirectResult, type NotFoundResult, type RedirectResult } from "../route.ts";
+export { isNotFoundResult, isRedirectResult, type NotFoundResult, type RedirectResult };
+export { runMiddleware } from "../router/middleware.ts";
+export type { ElizabethMiddleware, ElizabethRequestContext, MiddlewareReference } from "../router/middleware.ts";
+
+export function methodNotAllowedResponse(methods: string[]): Response {
+  return new Response("Method Not Allowed", {
+    status: 405,
+    headers: {
+      allow: methods.join(", "),
+      "content-type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+export function apiRouteBuildFailureResponse(route: { path: string; error?: string | null }): Response {
+  return new Response(`API route failed to build: ${route.path}\n${route.error ?? "Unknown error"}`, {
+    status: 500,
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+    },
+  });
+}
+
+export function responseFromResult(
+  result: unknown,
+  pathname: string,
+  renderNotFound: () => Response | Promise<Response>
+): Response | Promise<Response> {
+  if (result instanceof Response) {
+    return result;
+  }
+
+  if (isRedirectResult(result)) {
+    return new Response(null, {
+      status: result.status,
+      headers: { location: result.location },
+    });
+  }
+
+  if (isNotFoundResult(result)) {
+    return renderNotFound();
+  }
+
+  if (typeof result === "string") {
+    return new Response(result, {
+      headers: {
+        "content-type": "text/html; charset=utf-8",
+      },
+    });
+  }
+
+  return Response.json(result);
+}
+
+export async function renderApiRoute(
+  match: any,
+  method: string,
+  request: Request,
+  resolveModule: (route: any) => any,
+  context?: any,
+  renderNotFound?: () => Response | Promise<Response>
+): Promise<Response> {
+  if (match.route.error) {
+    return apiRouteBuildFailureResponse(match.route);
+  }
+
+  const module = await resolveModule(match.route);
+  let handler = match.route.handlers?.[method] ?? module[method];
+
+  if (!handler) {
+    return methodNotAllowedResponse(match.route.methods);
+  }
+
+  const result = await handler(
+    context ?? {
+      request,
+      pathname: new URL(request.url).pathname,
+      params: match.params,
+      locals: {},
+      get url() {
+        return new URL(request.url);
+      },
+    }
+  );
+
+  return responseFromResult(result, new URL(request.url).pathname, renderNotFound ?? (() => {
+    return new Response("Not found", {
+      status: 404,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    });
+  })) as Response;
+}
+
+export function escapeAttribute(value: string): string {
+  return Bun.escapeHTML(value);
+}
+
+export function hashString(value: string): string {
+  let hash = 5381;
+  for (let index = 0; index < value.length; index++) {
+    hash = ((hash << 5) + hash) ^ value.charCodeAt(index);
+  }
+  return (hash >>> 0).toString(36);
+}
+
+export function routeBoundary(key: string, html: string): string {
+  return `<elizabeth-route-boundary data-elizabeth-boundary="${escapeAttribute(key)}" style="display: contents">${html}</elizabeth-route-boundary>`;
+}
+
+export function boundaryKey(sourcePath: string, params: Record<string, string>, layoutIndex: number): string {
+  if (layoutIndex === 0) return `layout:${hashString(sourcePath)}:`;
+  let key = "";
+  for (const name in params) key += name + "=" + params[name] + "&";
+  return `layout:${hashString(sourcePath)}:${key}`;
+}
+
+export function dedupeElizabethStyles(html: string): string {
+  const seen = new Set<string>();
+
+  return html.replace(
+    /<style\b([^>]*\sdata-elizabeth-style=(["'])(.*?)\2[^>]*)>[\s\S]*?<\/style>/g,
+    (style, _attrs: string, _quote: string, id: string) => {
+      if (seen.has(id)) {
+        return "";
+      }
+
+      seen.add(id);
+      return style;
+    },
+  );
+}
+
+export function renderPageRoute(
+  match: any,
+  resolveModule: (path: string) => any,
+  context?: any
+): any {
+  const ctx = context ? { ...context, params: match.params, error: match.error } : { params: match.params, error: match.error, locals: {} };
+  const moduleIdentifier = match.route.module || match.route.outputPath;
+  const page = resolveModule(moduleIdentifier);
+  
+  if (page instanceof Promise) {
+    return page.then((resolvedPage) => {
+      const html = resolvedPage.default({}, ctx);
+      if (html instanceof Promise) {
+        return html.then((resolvedHtml) => renderRouteLayouts(match, resolveModule, ctx, resolvedHtml, match.route.layouts.length - 1));
+      }
+      return renderRouteLayouts(match, resolveModule, ctx, html, match.route.layouts.length - 1);
+    });
+  }
+
+  const html = page.default({}, ctx);
+  if (html instanceof Promise) {
+    return html.then((resolvedHtml) => renderRouteLayouts(match, resolveModule, ctx, resolvedHtml, match.route.layouts.length - 1));
+  }
+
+  return renderRouteLayouts(match, resolveModule, ctx, html, match.route.layouts.length - 1);
+}
+
+function renderRouteLayouts(match: any, resolveModule: (path: string) => any, ctx: any, html: any, layoutIndex: number): any {
+  if (isRedirectResult(html) || isNotFoundResult(html)) {
+    return html;
+  }
+
+  let current = html;
+
+  for (let index = layoutIndex; index >= 0; index--) {
+    const layout = match.route.layouts[index];
+    const moduleIdentifier = layout.module || layout.outputPath;
+    const modulePromise = resolveModule(moduleIdentifier);
+    
+    if (modulePromise instanceof Promise) {
+      return modulePromise.then((module) => {
+        const result = module.default({
+          children: routeBoundary(boundaryKey(layout.hash || layout.sourcePath, match.params, index), current)
+        }, ctx);
+        
+        if (result instanceof Promise) {
+          return result.then((resolved) => renderRouteLayouts(match, resolveModule, ctx, resolved, index - 1));
+        }
+        return renderRouteLayouts(match, resolveModule, ctx, result, index - 1);
+      });
+    }
+
+    const result = modulePromise.default({
+      children: routeBoundary(boundaryKey(layout.hash || layout.sourcePath, match.params, index), current)
+    }, ctx);
+
+    if (result instanceof Promise) {
+      return result.then((resolved) => renderRouteLayouts(match, resolveModule, ctx, resolved, index - 1));
+    }
+    
+    current = result;
+    if (isRedirectResult(current) || isNotFoundResult(current)) {
+      return current;
+    }
+  }
+
+  return typeof current === "string" && current.includes("data-elizabeth-style=") ? dedupeElizabethStyles(current) : current;
+}
+
+
+export function createRequestContext(
+  request: Request,
+  pathname: string,
+  params: Record<string, string>,
+  error?: unknown,
+) {
+  return {
+    request,
+    pathname,
+    params,
+    locals: {},
+    error,
+    get url() {
+      return new URL(request.url);
+    },
+  };
+}
+
+export function resolveMiddleware(
+  references: any[] = [],
+  globalMiddlewareCount: number,
+  getConfigMiddleware: (index: number) => any,
+  resolveModule: (path: string) => any
+): any {
+  const middleware: any[] = [];
+
+  for (let index = 0; index < globalMiddlewareCount; index++) {
+    const entry = getConfigMiddleware(index);
+    if (entry) middleware.push(entry);
+  }
+
+  for (const reference of references) {
+    if (reference.kind === "config") {
+      const entry = getConfigMiddleware(reference.index);
+      if (entry) middleware.push(entry);
+      continue;
+    }
+
+    const modulePromise = resolveModule(reference.module || reference.outputPath);
+    if (modulePromise instanceof Promise) {
+      middleware.push(modulePromise.then((module) => {
+        const entry = module?.default ?? module?.middleware;
+        if (typeof entry !== "function") {
+          throw new Error("Middleware module must export a default function or named middleware: " + reference.sourcePath);
+        }
+        return entry;
+      }));
+    } else {
+      const entry = modulePromise?.default ?? modulePromise?.middleware;
+      if (typeof entry !== "function") {
+        throw new Error("Middleware module must export a default function or named middleware: " + reference.sourcePath);
+      }
+      middleware.push(entry);
+    }
+  }
+
+  if (middleware.some((m) => m instanceof Promise)) {
+    return Promise.all(middleware);
+  }
+  return middleware;
+}


### PR DESCRIPTION
- Extract duplicated server runtime logic from dev/prod environments into a unified `src/runtime/server.ts` module, exported as `elizabeth/server`.
- Remove overly aggressive `staticHtmlCache` from the production compiler. Parameter-less pages (like `/`) are no longer permanently cached on server start, allowing them to dynamically read fresh data per request.
- Fix an infinite recursion bug in `resolveMiddlewareWrapper` inside the generated production server that caused POST requests to hang.
- Refactor page rendering to delegate to `renderPageRoute` centrally.

## Summary

<!-- What changed in this PR? -->

- Extracted common server logic (middleware resolution, error responses, layout boundaries) into a shared `src/runtime/server.ts` module to achieve dev/prod parity.
- Fixed a major caching bug in production where routes without dynamic parameters were permanently cached at startup, preventing data-driven pages from updating.
- Fixed an infinite recursion bug in the generated production server's middleware wrapper that caused API requests to hang.

## Type of change

<!-- Check all that apply. -->

- [x] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI / tooling
- [ ] Performance
- [ ] Breaking change

## Changes made

<!-- Add more detail if needed. -->

- **`package.json`**: Added `"./server": "./src/runtime/server.ts"` to the `exports` map so the generated server can import it.
- **`src/runtime/server.ts`**: Created this new file to centralize routing, middleware, and response logic.
- **`src/build/app.ts`**: Removed the massive inline function strings from the generated server output. Removed the `staticHtmlCache` mechanism and fixed the `resolveMiddlewareWrapper` recursion.
- **`src/dev/app.ts`** & **`src/router/render.ts`**: Refactored to import and use the new shared runtime utilities.

## Testing

<!-- What did you run? -->

- [x] `bun run check`
- [x] `bun run test`
- [x] `bun run build`
- [x] Manual test

Notes:

- All 256 core tests pass.
- Manually tested by linking to the `blog-sqlite` example, compiling the production build, and verifying that new and deleted posts correctly update the home page without requiring a server restart. Also verified that `POST` requests to the API process cleanly without hanging.

## Checklist

- [x] This PR has a clear scope
- [x] Existing behavior is preserved unless noted
- [x] Public API changes are documented
- [x] Tests were added or updated where useful
- [x] I did not add unnecessary dependencies
